### PR TITLE
Bug Fixes for generate, cleardb and setnodes commands

### DIFF
--- a/DBCreator/DBCreator.py
+++ b/DBCreator/DBCreator.py
@@ -353,10 +353,10 @@ class MainMenu(cmd.Cmd):
 
             if (len(props) > 500):
                 session.run(
-                    'UNWIND {props} as prop MERGE (n:Base {objectid: prop.id}) SET n:Computer, n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+                    'UNWIND $props as prop MERGE (n:Base {objectid: prop.id}) SET n:Computer, n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
                 props = []
         session.run(
-            'UNWIND {props} as prop MERGE (n:Base {objectid:prop.id}) SET n:Computer, n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+            'UNWIND $props as prop MERGE (n:Base {objectid:prop.id}) SET n:Computer, n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
 
         print("Creating Domain Controllers")
         for state in states:
@@ -401,11 +401,11 @@ class MainMenu(cmd.Cmd):
             }})
             if (len(props) > 500):
                 session.run(
-                    'UNWIND {props} as prop MERGE (n:Base {objectid:prop.id}) SET n:User, n += prop.props WITH n MATCH (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+                    'UNWIND $props as prop MERGE (n:Base {objectid:prop.id}) SET n:User, n += prop.props WITH n MATCH (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
                 props = []
 
         session.run(
-            'UNWIND {props} as prop MERGE (n:Base {objectid:prop.id}) SET n:User, n += prop.props WITH n MATCH (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+            'UNWIND $props as prop MERGE (n:Base {objectid:prop.id}) SET n:User, n += prop.props WITH n MATCH (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
 
         print("Generating Group Nodes")
         weighted_parts = ["IT"] * 7 + ["HR"] * 13 + \
@@ -420,11 +420,11 @@ class MainMenu(cmd.Cmd):
             props.append({'name': group_name, 'id': sid})
             if len(props) > 500:
                 session.run(
-                    'UNWIND {props} as prop MERGE (n:Base {objectid:prop.id}) SET n:Group, n.name=prop.name', props=props)
+                    'UNWIND $props as prop MERGE (n:Base {objectid:prop.id}) SET n:Group, n.name=prop.name', props=props)
                 props = []
 
         session.run(
-            'UNWIND {props} as prop MERGE (n:Base {objectid:prop.id}) SET n:Group, n.name=prop.name', props=props)
+            'UNWIND $props as prop MERGE (n:Base {objectid:prop.id}) SET n:Group, n.name=prop.name', props=props)
 
         print("Adding Domain Admins to Local Admins of Computers")
         session.run(
@@ -458,11 +458,11 @@ class MainMenu(cmd.Cmd):
 
             if (len(props) > 500):
                 session.run(
-                    'UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+                    'UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
                 props = []
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
 
         print("Adding users to groups")
         props = []
@@ -496,11 +496,11 @@ class MainMenu(cmd.Cmd):
 
             if len(props) > 500:
                 session.run(
-                    'UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+                    'UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
                 props = []
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
 
         it_users = it_users + das
         it_users = list(set(it_users))
@@ -534,7 +534,7 @@ class MainMenu(cmd.Cmd):
 
             if len(props) > 500:
                 session.run(
-                    'UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
+                    'UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
                 props = []
 
         for x in super_groups:
@@ -543,11 +543,11 @@ class MainMenu(cmd.Cmd):
 
             if len(props) > 500:
                 session.run(
-                    'UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
+                    'UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
                 props = []
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
 
         print("Adding RDP/ExecuteDCOM/AllowedToDelegateTo")
         count = int(math.floor(len(computers) * .1))
@@ -558,7 +558,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
 
         props = []
         for i in range(0, count):
@@ -567,7 +567,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
 
         props = []
         for i in range(0, count):
@@ -576,7 +576,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
 
         props = []
         for i in range(0, count):
@@ -585,7 +585,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
 
         props = []
         for i in range(0, count):
@@ -594,7 +594,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
 
         props = []
         for i in range(0, count):
@@ -605,7 +605,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:Computer {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:Computer {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
 
         print("Adding sessions")
         max_sessions_per_user = int(math.ceil(math.log10(self.num_nodes)))
@@ -624,11 +624,11 @@ class MainMenu(cmd.Cmd):
 
             if (len(props) > 500):
                 session.run(
-                    'UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
+                    'UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
                 props = []
 
         session.run(
-            'UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
+            'UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
 
         print("Adding Domain Admin ACEs")
         group_name = "DOMAIN ADMINS@{}".format(self.domain)
@@ -638,33 +638,33 @@ class MainMenu(cmd.Cmd):
 
             if len(props) > 500:
                 session.run(
-                    'UNWIND {props} as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+                    'UNWIND $props as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
                 props = []
 
         session.run(
-            'UNWIND {props} as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+            'UNWIND $props as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
 
         for x in users:
             props.append({'name': x})
 
             if len(props) > 500:
                 session.run(
-                    'UNWIND {props} as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+                    'UNWIND $props as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
                 props = []
 
         session.run(
-            'UNWIND {props} as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+            'UNWIND $props as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
 
         for x in groups:
             props.append({'name': x})
 
             if len(props) > 500:
                 session.run(
-                    'UNWIND {props} as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+                    'UNWIND $props as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
                 props = []
 
         session.run(
-            'UNWIND {props} as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+            'UNWIND $props as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
 
         print("Creating OUs")
         temp_comps = computers
@@ -682,11 +682,11 @@ class MainMenu(cmd.Cmd):
                 props.append({'compname': c, 'ouguid': guid, 'ouname': ouname})
                 if len(props) > 500:
                     session.run(
-                        'UNWIND {props} as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+                        'UNWIND $props as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
                     props = []
 
         session.run(
-            'UNWIND {props} as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+            'UNWIND $props as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
 
         temp_users = users
         random.shuffle(temp_users)
@@ -703,11 +703,11 @@ class MainMenu(cmd.Cmd):
                 props.append({'username': c, 'ouguid': guid, 'ouname': ouname})
                 if len(props) > 500:
                     session.run(
-                        'UNWIND {props} as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+                        'UNWIND $props as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
                     props = []
 
         session.run(
-            'UNWIND {props} as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+            'UNWIND $props as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:Base {objectid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) SET m:OU WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
 
         props = []
         for x in list(ou_guid_map.keys()):
@@ -715,7 +715,7 @@ class MainMenu(cmd.Cmd):
             props.append({'b': guid})
 
         session.run(
-            'UNWIND {props} as prop MERGE (n:OU {objectid:prop.b}) WITH n MERGE (m:Domain {name:$domain}) WITH n,m MERGE (m)-[:Contains]->(n)', props=props, domain=self.domain)
+            'UNWIND $props as prop MERGE (n:OU {objectid:prop.b}) WITH n MERGE (m:Domain {name:$domain}) WITH n,m MERGE (m)-[:Contains]->(n)', props=props, domain=self.domain)
 
         print("Creating GPOs")
 
@@ -762,35 +762,35 @@ class MainMenu(cmd.Cmd):
                 p = random.choice(all_principals)
                 p2 = random.choice(gpos)
                 session.run(
-                    'MERGE (n:Group {name:{group}}) MERGE (m {name:{principal}}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
-                session.run('MERGE (n:Group {name:{group}}) MERGE (m:GPO {name:{principal}}) MERGE (n)-' +
+                    'MERGE (n:Group {name:$group}) MERGE (m {name:$principal}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
+                session.run('MERGE (n:Group {name:$group}) MERGE (m:GPO {name:$principal}) MERGE (n)-' +
                             ace_string + '->(m)', group=i, principal=p2)
             elif ace == 'AddMember':
                 p = random.choice(it_groups)
                 session.run(
-                    'MERGE (n:Group {name:{group}}) MERGE (m:Group {name:{principal}}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
+                    'MERGE (n:Group {name:$group}) MERGE (m:Group {name:$principal}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
             elif ace == 'ReadLAPSPassword':
                 p = random.choice(all_principals)
                 targ = random.choice(computers)
                 session.run(
-                    'MERGE (n {name:{principal}}) MERGE (m:Computer {name:{target}}) MERGE (n)-[r:ReadLAPSPassword]->(m)', target=targ, principal=p)
+                    'MERGE (n {name:$principal}) MERGE (m:Computer {name:$target}) MERGE (n)-[r:ReadLAPSPassword]->(m)', target=targ, principal=p)
             else:
                 p = random.choice(it_users)
                 session.run(
-                    'MERGE (n:Group {name:{group}}) MERGE (m:User {name:{principal}}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
+                    'MERGE (n:Group {name:$group}) MERGE (m:User {name:$principal}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
 
         print("Marking some users as Kerberoastable")
         i = random.randint(10, 20)
         i = min(i, len(it_users))
         for user in random.sample(it_users, i):
             session.run(
-                'MATCH (n:User {name:{user}}) SET n.hasspn=true', user=user)
+                'MATCH (n:User {name:$user}) SET n.hasspn=true', user=user)
 
         print("Adding unconstrained delegation to a few computers")
         i = random.randint(10, 20)
         i = min(i, len(computers))
         session.run(
-            'MATCH (n:Computer {name:{user}}) SET n.unconstrainteddelegation=true', user=user)
+            'MATCH (n:Computer {name:$user}) SET n.unconstrainteddelegation=true', user=user)
 
         session.run('MATCH (n:User) SET n.owned=false')
         session.run('MATCH (n:Computer) SET n.owned=false')

--- a/DBCreator/DBCreator.py
+++ b/DBCreator/DBCreator.py
@@ -126,12 +126,21 @@ class MainMenu(cmd.Cmd):
         if passed != "":
             try:
                 self.num_nodes = int(passed)
-                return
+                if self.num_nodes < 282:
+                    self.num_nodes = 500
+                    self.do_setnodes("")
+                else:
+                    return
             except ValueError:
                 pass
-
-        self.num_nodes = int(self.m.input_default(
-            "Number of nodes of each type to generate", self.num_nodes))
+        else:
+            self.num_nodes = int(self.m.input_default(
+                "Number of nodes of each type to generate (min value: 282)", self.num_nodes))
+            if self.num_nodes < 282:
+                self.num_nodes = 500
+                self.do_setnodes("")
+            else:
+                return
 
     def do_setdomain(self, args):
         passed = args
@@ -161,6 +170,7 @@ class MainMenu(cmd.Cmd):
         print("Clearing Database")
         d = self.driver
         session = d.session()
+        """
         num = 1
         while num > 0:
             result = session.run(
@@ -178,6 +188,10 @@ class MainMenu(cmd.Cmd):
         session.run(
             "CREATE CONSTRAINT id_constraint ON (c:Base) ASSERT c.objectid IS UNIQUE")
         session.run("CREATE INDEX name_index FOR (n:Base) ON (n.name)")
+        """
+
+        session.run("match (a) -[r] -> () delete a, r")
+        session.run("match (a) delete a")
 
         session.close()
 

--- a/DBCreator/DBCreator.py
+++ b/DBCreator/DBCreator.py
@@ -45,7 +45,7 @@ class MainMenu(cmd.Cmd):
         self.m = Messages()
         self.url = "bolt://localhost:7687"
         self.username = "neo4j"
-        self.password = "neo4jj"
+        self.password = "password"
         self.use_encryption = False
         self.driver = None
         self.connected = False
@@ -126,21 +126,25 @@ class MainMenu(cmd.Cmd):
         if passed != "":
             try:
                 self.num_nodes = int(passed)
+                """
                 if self.num_nodes < 282:
                     self.num_nodes = 500
                     self.do_setnodes("")
                 else:
                     return
+                """
             except ValueError:
                 pass
         else:
             self.num_nodes = int(self.m.input_default(
-                "Number of nodes of each type to generate (min value: 282)", self.num_nodes))
+                "Number of nodes of each type to generate", self.num_nodes))
+            """
             if self.num_nodes < 282:
                 self.num_nodes = 500
                 self.do_setnodes("")
             else:
                 return
+            """
 
     def do_setdomain(self, args):
         passed = args
@@ -488,6 +492,8 @@ class MainMenu(cmd.Cmd):
         variance = int(math.ceil(math.log10(self.num_nodes)))
         it_users = []
 
+        print("\n\nNUM GROUPS BASE:", num_groups_base)
+
         print("Calculated {} groups per user with a variance of - {}".format(num_groups_base, variance*2))
 
         for user in users:
@@ -500,9 +506,11 @@ class MainMenu(cmd.Cmd):
             if (sample > len(possible_groups)):
                 sample = int(math.floor(float(len(possible_groups)) / 4))
 
-            if (sample == 0):
+            if (sample <= 1):
                 continue
 
+            print("\n\nPOSSIBLE GROUPS:\n", possible_groups)
+            print("\n\nSAMPLE:\n", sample)
             to_add = random.sample(possible_groups, sample)
 
             for group in to_add:
@@ -522,7 +530,12 @@ class MainMenu(cmd.Cmd):
         print("Adding local admin rights")
         it_groups = [x for x in groups if "IT" in x]
         random.shuffle(it_groups)
-        super_groups = random.sample(it_groups, 4)
+        print("LEN IT_GROUPS:", len(it_groups))
+        if len(it_groups) <= 4:
+            max_lim = random.randint(1, len(it_groups) - 1)
+        else:
+            max_lim = 4
+        super_groups = random.sample(it_groups, max_lim)
         super_group_num = int(math.floor(len(computers) * .85))
 
         it_groups = [x for x in it_groups if not x in super_groups]

--- a/DBCreator/DBCreator.py.bak
+++ b/DBCreator/DBCreator.py.bak
@@ -319,9 +319,9 @@ class MainMenu(cmd.Cmd):
             }})
 
             if (len(props) > 500):
-                session.run('UNWIND {props} as prop MERGE (n:Base {objectid: prop.id}) SET n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+                session.run('UNWIND $props as prop MERGE (n:Base {objectid: prop.id}) SET n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
                 props = []
-        session.run('UNWIND {props} as prop MERGE (n:Computer {name:prop.name}) WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+        session.run('UNWIND $props as prop MERGE (n:Computer {name:prop.name}) WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
 
         print "Creating Domain Controllers"
         for state in states:
@@ -369,11 +369,11 @@ class MainMenu(cmd.Cmd):
             }})
             if (len(props) > 500):
                 session.run(
-                    'UNWIND {props} as prop MERGE (n:User {name:prop.name}) SET n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+                    'UNWIND $props as prop MERGE (n:User {name:prop.name}) SET n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
                 props = []
                 
         session.run(
-            'UNWIND {props} as prop MERGE (n:User {name:prop.name}) SET n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
+            'UNWIND $props as prop MERGE (n:User {name:prop.name}) SET n += prop.props WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props, gname=group_name)
 
         
         print "Generating Group Nodes"
@@ -385,11 +385,11 @@ class MainMenu(cmd.Cmd):
             groups.append(group_name)
             props.append({'name':group_name})
             if len(props) > 500:
-                session.run('UNWIND {props} as prop MERGE (n:Group {name:prop.name})', props=props)
+                session.run('UNWIND $props as prop MERGE (n:Group {name:prop.name})', props=props)
                 props = []
         
         session.run(
-            'UNWIND {props} as prop MERGE (n:Group {name:prop.name})', props=props)
+            'UNWIND $props as prop MERGE (n:Group {name:prop.name})', props=props)
         
         print "Adding Domain Admins to Local Admins of Computers"
         props = []
@@ -397,11 +397,11 @@ class MainMenu(cmd.Cmd):
         for comp in computers:
             props.append({'name':comp})
             if len(props) > 500:
-                session.run('UNWIND {props} as prop MERGE (n:Computer {name:prop.name}) WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (m)-[:AdminTo]->(n)', props=props, gname=group_name)
+                session.run('UNWIND $props as prop MERGE (n:Computer {name:prop.name}) WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (m)-[:AdminTo]->(n)', props=props, gname=group_name)
                 props = []
         
         session.run(
-            'UNWIND {props} as prop MERGE (n:Computer {name:prop.name}) WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (m)-[:AdminTo]->(n)', props=props, gname=group_name)
+            'UNWIND $props as prop MERGE (n:Computer {name:prop.name}) WITH n MERGE (m:Group {name:$gname}) WITH n,m MERGE (m)-[:AdminTo]->(n)', props=props, gname=group_name)
         
         dapctint = random.randint(3,5)
         dapct = float(dapctint) / 100
@@ -430,10 +430,10 @@ class MainMenu(cmd.Cmd):
                         props.append({'a':group,'b':g})
                 
             if (len(props) > 500):
-                session.run('UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+                session.run('UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
                 props = []
         
-        session.run('UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
         
         print "Adding users to groups"
         props = []
@@ -466,11 +466,11 @@ class MainMenu(cmd.Cmd):
                 props.append({'a':user,'b':group})
             
             if len(props) > 500:
-                session.run('UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+                session.run('UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
                 props = []
         
         session.run(
-            'UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
+            'UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Group {name:prop.b}) WITH n,m MERGE (n)-[:MemberOf]->(m)', props=props)
         
         it_users = it_users + das
         it_users = list(set(it_users))
@@ -502,7 +502,7 @@ class MainMenu(cmd.Cmd):
                 props.append({'a': g, 'b': a})
 
             if len(props) > 500:
-                session.run('UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
+                session.run('UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
                 props = []
         
         for x in super_groups:
@@ -510,10 +510,10 @@ class MainMenu(cmd.Cmd):
                 props.append({'a': x, 'b': a})
             
             if len(props) > 500:
-                session.run('UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
+                session.run('UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
                 props = []
 
-        session.run('UNWIND {props} AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:Group {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (n)-[:AdminTo]->(m)', props=props)
         
         print "Adding RDP/ExecuteDCOM/AllowedToDelegateTo"
         count = int(math.floor(len(computers) * .1))
@@ -524,7 +524,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
         
 
-        session.run('UNWIND {props} AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
 
         props = []
         for i in xrange(0, count):
@@ -533,7 +533,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
         
 
-        session.run('UNWIND {props} AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
 
         props = []
         for i in xrange(0, count):
@@ -542,7 +542,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
         
 
-        session.run('UNWIND {props} AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:CanRDP]->(m)', props=props)
 
         props = []
         for i in xrange(0, count):
@@ -551,7 +551,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
         
 
-        session.run('UNWIND {props} AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:Group {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:ExecuteDCOM]->(m)', props=props)
 
         props = []
         for i in xrange(0, count):
@@ -560,7 +560,7 @@ class MainMenu(cmd.Cmd):
             props.append({'a': user, 'b': comp})
         
 
-        session.run('UNWIND {props} AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:User {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
 
         props = []
         for i in xrange(0, count):
@@ -570,7 +570,7 @@ class MainMenu(cmd.Cmd):
                 continue
             props.append({'a': user, 'b': comp})
         
-        session.run('UNWIND {props} AS prop MERGE (n:Computer {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:Computer {name: prop.a}) MERGE (m:Computer {name: prop.b}) MERGE (n)-[r:AllowedToDelegate]->(m)', props=props)
 
         print "Adding sessions"
         max_sessions_per_user = int(math.ceil(math.log10(self.num_nodes)))
@@ -588,10 +588,10 @@ class MainMenu(cmd.Cmd):
                 props.append({'a':user,'b':c})
             
             if (len(props) > 500):
-                session.run('UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
+                session.run('UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
                 props = []
         
-        session.run('UNWIND {props} AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
+        session.run('UNWIND $props AS prop MERGE (n:User {name:prop.a}) WITH n,prop MERGE (m:Computer {name:prop.b}) WITH n,m MERGE (m)-[:HasSession]->(n)', props=props)
 
         print "Adding Domain Admin ACEs"
         group_name = "DOMAIN ADMINS@{}".format(self.domain)
@@ -600,28 +600,28 @@ class MainMenu(cmd.Cmd):
             props.append({'name':x})
 
             if len(props) > 500:
-                session.run('UNWIND {props} as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+                session.run('UNWIND $props as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
                 props = []
         
-        session.run('UNWIND {props} as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+        session.run('UNWIND $props as prop MATCH (n:Computer {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
 
         for x in users:
             props.append({'name':x})
 
             if len(props) > 500:
-                session.run('UNWIND {props} as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+                session.run('UNWIND $props as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
                 props = []
         
-        session.run('UNWIND {props} as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+        session.run('UNWIND $props as prop MATCH (n:User {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
 
         for x in groups:
             props.append({'name':x})
 
             if len(props) > 500:
-                session.run('UNWIND {props} as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+                session.run('UNWIND $props as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
                 props = []
         
-        session.run('UNWIND {props} as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
+        session.run('UNWIND $props as prop MATCH (n:Group {name:prop.name}) WITH n MATCH (m:Group {name:$gname}) WITH m,n MERGE (m)-[r:GenericAll {isacl:true}]->(n)', props=props, gname=group_name)
 
         print "Creating OUs"
         temp_comps = computers
@@ -638,10 +638,10 @@ class MainMenu(cmd.Cmd):
             for c in ou_comps:
                 props.append({'compname':c,'ouguid':guid,'ouname':ouname})
                 if len(props) > 500:
-                    session.run('UNWIND {props} as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+                    session.run('UNWIND $props as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
                     props = []
         
-        session.run('UNWIND {props} as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+        session.run('UNWIND $props as prop MERGE (n:Computer {name:prop.compname}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
 
         temp_users = users
         random.shuffle(temp_users)
@@ -658,17 +658,17 @@ class MainMenu(cmd.Cmd):
                 props.append({'username':c,'ouguid':guid,'ouname':ouname})
                 if len(props) > 500:
                     session.run(
-                        'UNWIND {props} as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+                        'UNWIND $props as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
                     props = []
         
-        session.run('UNWIND {props} as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
+        session.run('UNWIND $props as prop MERGE (n:User {name:prop.username}) WITH n,prop MERGE (m:OU {guid:prop.ouguid, name:prop.ouname, blocksInheritance: false}) WITH n,m,prop MERGE (m)-[:Contains]->(n)', props=props)
 
         props = []
         for x in ou_guid_map.keys():
             guid = ou_guid_map[x]
             props.append({'b':guid})
         
-        session.run('UNWIND {props} as prop MERGE (n:OU {guid:prop.b}) WITH n MERGE (m:Domain {name:$domain}) WITH n,m MERGE (m)-[:Contains]->(n)', props=props, domain=self.domain)
+        session.run('UNWIND $props as prop MERGE (n:OU {guid:prop.b}) WITH n MERGE (m:Domain {name:$domain}) WITH n,m MERGE (m)-[:Contains]->(n)', props=props, domain=self.domain)
 
         print "Creating GPOs"
 
@@ -709,29 +709,29 @@ class MainMenu(cmd.Cmd):
             if ace == "GenericAll" or ace == 'GenericWrite' or ace == 'WriteOwner' or ace == 'WriteDacl':
                 p = random.choice(all_principals)
                 p2 = random.choice(gpos)
-                session.run('MERGE (n:Group {name:{group}}) MERGE (m {name:{principal}}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
-                session.run('MERGE (n:Group {name:{group}}) MERGE (m:GPO {name:{principal}}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p2)
+                session.run('MERGE (n:Group {name:$group}) MERGE (m {name:$principal}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
+                session.run('MERGE (n:Group {name:$group}) MERGE (m:GPO {name:$principal}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p2)
             elif ace == 'AddMember':
                 p = random.choice(it_groups)
-                session.run('MERGE (n:Group {name:{group}}) MERGE (m:Group {name:{principal}}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
+                session.run('MERGE (n:Group {name:$group}) MERGE (m:Group {name:$principal}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
             elif ace == 'ReadLAPSPassword':
                 p = random.choice(all_principals)
                 targ = random.choice(computers)
-                session.run('MERGE (n {name:{principal}}) MERGE (m:Computer {name:{target}}) MERGE (n)-[r:ReadLAPSPassword]->(m)', target=targ, principal=p)
+                session.run('MERGE (n {name:$principal}) MERGE (m:Computer {name:$target}) MERGE (n)-[r:ReadLAPSPassword]->(m)', target=targ, principal=p)
             else:
                 p = random.choice(it_users)
-                session.run('MERGE (n:Group {name:{group}}) MERGE (m:User {name:{principal}}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
+                session.run('MERGE (n:Group {name:$group}) MERGE (m:User {name:$principal}) MERGE (n)-' + ace_string + '->(m)', group=i, principal=p)
 
         print "Marking some users as Kerberoastable"
         i = random.randint(10,20)
         i = min(i, len(it_users))
         for user in random.sample(it_users,i):
-            session.run('MATCH (n:User {name:{user}}) SET n.hasspn=true', user=user)
+            session.run('MATCH (n:User {name:$user}) SET n.hasspn=true', user=user)
 
         print "Adding unconstrained delegation to a few computers"
         i = random.randint(10,20)
         i = min(i, len(computers))
-        session.run('MATCH (n:Computer {name:{user}}) SET n.unconstrainteddelegation=true', user=user)
+        session.run('MATCH (n:Computer {name:$user}) SET n.unconstrainteddelegation=true', user=user)
 
         session.run('MATCH (n:User) SET n.owned=false')
         session.run('MATCH (n:Computer) SET n.owned=false')

--- a/DBCreator/README.md
+++ b/DBCreator/README.md
@@ -8,7 +8,7 @@ This script requires Python 3.7+, as well as the `neo4j` module. The script will
 
 ## Running
 
-Ensure that all files in this repo are in the same directory.
+Open a terminal and run the following commands:
 
 ```sh
 $ git clone https://github.com/nicolas-carolo/BloodHound-Tools

--- a/DBCreator/README.md
+++ b/DBCreator/README.md
@@ -4,26 +4,19 @@ This python script will generate a randomized data set for testing BloodHound fe
 
 ## Requirements
 
-This script requires Python 3.7+, as well as the neo4j module. The script will only work with BloodHound 3.0.0 and above.
-
-The Neo4j module can be installed using pip:
-
-```
-pip install neo4j
-```
-
-or
-
-```
-pip install -r requirements.txt
-```
+This script requires Python 3.7+, as well as the `neo4j` module. The script will only work with BloodHound 3.0.0 and above.
 
 ## Running
 
 Ensure that all files in this repo are in the same directory.
 
-```
-python DBCreator.py
+```sh
+$ git clone https://github.com/nicolas-carolo/BloodHound-Tools
+$ cd BloodHound-Tools/DBCreator
+$ python3 -m venv ./venv
+$ source venv/bin/activate
+$ pip3 install -r requirements.txt
+$ python3 DBCreator.py
 ```
 
 ## Commands
@@ -36,15 +29,3 @@ python DBCreator.py
 - generate - Generates random data in the database
 - clear_and_generate - Connects to the database, clears the DB, sets the schema, and generates random data
 - exit - Exits the script
-
-
-## How to run DBCreator
-Open a terminal and run the following commands:
-```sh
-$ git clone https://github.com/nicolas-carolo/BloodHound-Tools
-$ cd BloodHound-Tools/DBCreator
-$ python3 -m venv ./venv
-$ source venv/bin/activate
-$ pip3 install -r requirements.txt
-$ python3 DBCreator.py
-```

--- a/DBCreator/README.md
+++ b/DBCreator/README.md
@@ -4,12 +4,12 @@ This python script will generate a randomized data set for testing BloodHound fe
 
 ## Requirements
 
-This script requires Python 3.7+, as well as the neo4j-driver. The script will only work with BloodHound 3.0.0 and above.
+This script requires Python 3.7+, as well as the neo4j module. The script will only work with BloodHound 3.0.0 and above.
 
-The Neo4j Driver can be installed using pip:
+The Neo4j module can be installed using pip:
 
 ```
-pip install neo4j-driver
+pip install neo4j
 ```
 
 or
@@ -36,3 +36,15 @@ python DBCreator.py
 - generate - Generates random data in the database
 - clear_and_generate - Connects to the database, clears the DB, sets the schema, and generates random data
 - exit - Exits the script
+
+
+## How to run DBCreator
+Open a terminal and run the following commands:
+```sh
+$ git clone https://github.com/nicolas-carolo/BloodHound-Tools
+$ cd BloodHound-Tools/DBCreator
+$ python3 -m venv ./venv
+$ source venv/bin/activate
+$ pip3 install -r requirements.txt
+$ python3 DBCreator.py
+```


### PR DESCRIPTION
Hi, I found and fixed three bugs in DBCreator.py. Here is the list of my changes:
* New queries for erasing data into the database;
* New queries for populating the database compatible with the most recent versions of neo4j;
* now the limit on the minimum number of nodes is set to 282 for avoiding runtime errors.